### PR TITLE
Edr feature collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ This repository contains the edr-pydantic Python package. It provides [Pydantic]
 for the [OGC Environmental Data Retrieval (EDR) API](https://ogcapi.ogc.org/edr/).
 This can, for example, be used to help develop an EDR API using FastAPI.
 
+## Optional GeoJSON requirements for the EDR
+The EDR spec proposes to add [optional requirements](https://docs.ogc.org/is/19-086r4/19-086r4.html#toc9) to GeoJSON to help the user discover EDR resources. [GeoJSON Pydantic](https://github.com/developmentseed/geojson-pydantic) correctly ignores these extra attributes, as it is solely an implementation of GeoJSON, not EDR GeoJSON. Therefore, there is an EDR Feature collection model in this repository which is a limited implementation of the [EDRFeatureCollection implementation](https://schemas.opengis.net/ogcapi/edr/1.1/openapi/schemas/edr-geojson/edrFeatureCollectionGeoJSON.yaml). The model extends [GeoJSON Pydantic](https://github.com/developmentseed/geojson-pydantic) by adding the optional properties. In the future all the [EDR GeoJSON schemas](https://schemas.opengis.net/ogcapi/edr/1.1/openapi/schemas/edr-geojson/) should be in this repository.
+
+
 ## Install
 ```shell
 pip install edr-pydantic

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ for the [OGC Environmental Data Retrieval (EDR) API](https://ogcapi.ogc.org/edr/
 This can, for example, be used to help develop an EDR API using FastAPI.
 
 ## EDR GeoJSON
-The EDR spec adds [optional fields](https://docs.ogc.org/is/19-086r4/19-086r4.html#toc9) to GeoJSON to help the user discover EDR resources. Therefore, there is an EDR Feature collection model in this repository which is a limited implementation of the [EDRFeatureCollection implementation](https://schemas.opengis.net/ogcapi/edr/1.1/openapi/schemas/edr-geojson/edrFeatureCollectionGeoJSON.yaml). The model extends [GeoJSON Pydantic](https://github.com/developmentseed/geojson-pydantic) by adding the optional properties. 
+The EDR spec adds [optional fields](https://docs.ogc.org/is/19-086r4/19-086r4.html#toc9) to GeoJSON to help the user discover EDR resources. Therefore, there is an EDR Feature collection model in this repository which is a limited implementation of the [EDRFeatureCollection implementation](https://schemas.opengis.net/ogcapi/edr/1.1/openapi/schemas/edr-geojson/edrFeatureCollectionGeoJSON.yaml). The model extends [GeoJSON Pydantic](https://github.com/developmentseed/geojson-pydantic) by adding the optional properties.
 
 
 ## Install
@@ -189,6 +189,7 @@ This library is used to build an OGC Environmental Data Retrieval (EDR) API, ser
 Help is wanted in the following areas to fully implement the EDR spec:
 * See TODOs in code listing various small inconsistencies in the spec
 * In various places there could be more validation on content
+* In the future all the [EDR GeoJSON schemas](https://schemas.opengis.net/ogcapi/edr/1.1/openapi/schemas/edr-geojson/) should be in this repository.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ This repository contains the edr-pydantic Python package. It provides [Pydantic]
 for the [OGC Environmental Data Retrieval (EDR) API](https://ogcapi.ogc.org/edr/).
 This can, for example, be used to help develop an EDR API using FastAPI.
 
-## Optional GeoJSON requirements for the EDR
-The EDR spec proposes to add [optional requirements](https://docs.ogc.org/is/19-086r4/19-086r4.html#toc9) to GeoJSON to help the user discover EDR resources. [GeoJSON Pydantic](https://github.com/developmentseed/geojson-pydantic) correctly ignores these extra attributes, as it is solely an implementation of GeoJSON, not EDR GeoJSON. Therefore, there is an EDR Feature collection model in this repository which is a limited implementation of the [EDRFeatureCollection implementation](https://schemas.opengis.net/ogcapi/edr/1.1/openapi/schemas/edr-geojson/edrFeatureCollectionGeoJSON.yaml). The model extends [GeoJSON Pydantic](https://github.com/developmentseed/geojson-pydantic) by adding the optional properties. In the future all the [EDR GeoJSON schemas](https://schemas.opengis.net/ogcapi/edr/1.1/openapi/schemas/edr-geojson/) should be in this repository.
+## EDR GeoJSON
+The EDR spec adds [optional fields](https://docs.ogc.org/is/19-086r4/19-086r4.html#toc9) to GeoJSON to help the user discover EDR resources. Therefore, there is an EDR Feature collection model in this repository which is a limited implementation of the [EDRFeatureCollection implementation](https://schemas.opengis.net/ogcapi/edr/1.1/openapi/schemas/edr-geojson/edrFeatureCollectionGeoJSON.yaml). The model extends [GeoJSON Pydantic](https://github.com/developmentseed/geojson-pydantic) by adding the optional properties. 
 
 
 ## Install

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: GIS",
     "Typing :: Typed",
 ]
-version = "0.2.2"
+version = "0.3.0"
 dependencies = ["pydantic>=2.3,<3", "geojson-pydantic>1.0"]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 version = "0.3.0"
-dependencies = ["pydantic>=2.3,<3", "geojson-pydantic>1.0"]
+dependencies = ["pydantic>=2.3,<3", "geojson-pydantic>1.0,<2.0", "covjson-pydantic>=0.2.1,<0.3.0"]
 
 [project.optional-dependencies]
 test = ["pytest", "pytest-cov"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,8 +19,8 @@ classifiers = [
     "Topic :: Scientific/Engineering :: GIS",
     "Typing :: Typed",
 ]
-version = "0.2.1"
-dependencies = ["pydantic>=2.3,<3"]
+version = "0.2.2"
+dependencies = ["pydantic>=2.3,<3", "geojson-pydantic>1.0"]
 
 [project.optional-dependencies]
 test = ["pytest", "pytest-cov"]

--- a/src/edr_pydantic/edr_feature_collection.py
+++ b/src/edr_pydantic/edr_feature_collection.py
@@ -2,7 +2,7 @@ from typing import Dict
 
 from edr_pydantic.base_model import EdrBaseModel
 from edr_pydantic.parameter import Parameter
-from geojson_pydantic import FeatureCollection
+from geojson_pydantic import FeatureCollection  # type: ignore
 
 
 class EDRFeatureCollection(EdrBaseModel, FeatureCollection):

--- a/src/edr_pydantic/edr_feature_collection.py
+++ b/src/edr_pydantic/edr_feature_collection.py
@@ -1,7 +1,7 @@
 from typing import Dict
 
+from covjson_pydantic.parameter import Parameter  # type: ignore
 from edr_pydantic.base_model import EdrBaseModel
-from edr_pydantic.parameter import Parameter
 from geojson_pydantic import FeatureCollection  # type: ignore
 
 

--- a/src/edr_pydantic/edr_feature_collection.py
+++ b/src/edr_pydantic/edr_feature_collection.py
@@ -1,0 +1,9 @@
+from typing import Dict
+
+from edr_pydantic.base_model import EdrBaseModel
+from edr_pydantic.parameter import Parameter
+from geojson_pydantic import FeatureCollection
+
+
+class EDRFeatureCollection(EdrBaseModel, FeatureCollection):
+    parameters: Dict[str, Parameter]

--- a/src/edr_pydantic/edr_feature_collection.py
+++ b/src/edr_pydantic/edr_feature_collection.py
@@ -1,4 +1,5 @@
 from typing import Dict
+from typing import Optional
 
 from covjson_pydantic.parameter import Parameter  # type: ignore
 from edr_pydantic.base_model import EdrBaseModel
@@ -6,4 +7,4 @@ from geojson_pydantic import FeatureCollection  # type: ignore
 
 
 class EDRFeatureCollection(EdrBaseModel, FeatureCollection):
-    parameters: Dict[str, Parameter]
+    parameters: Optional[Dict[str, Parameter]] = None

--- a/tests/test_data/edr-geojson-feature-collection.json
+++ b/tests/test_data/edr-geojson-feature-collection.json
@@ -1,0 +1,88 @@
+{
+    "type": "FeatureCollection",
+    "features": [
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    5.1797,
+                    52.0989,
+                    1.9
+                ]
+            },
+            "properties": {
+                "name": "DE BILT AWS",
+                "parameter-name": [
+                    "air_temperature_1.5_maximum_PT10M",
+                    "dew_point_temperature_1.5_mean_PT1M",
+                    "duration_of_sunshine_2.0_point_PT0S",
+                    "wind_speed_10_mean_PT10M"
+                ]
+            },
+            "id": "06260"
+        }
+    ],
+    "parameters": {
+        "tx_dryb_10": {
+            "type": "Parameter",
+            "description": "Temperature, air, maximum, 10",
+            "unit": {
+                "label": "degree Celsius",
+                "symbol": {
+                    "value": "°C",
+                    "type": "http://www.opengis.net/def/uom/UCUM/"
+                }
+            },
+            "observedProperty": {
+                "id": "https://vocab.nerc.ac.uk/standard_name/air_temperature",
+                "label": "Air temperature maximum"
+            }
+        },
+        "t_dewp_10": {
+            "type": "Parameter",
+            "description": "Temperature air dewpoint 10",
+            "unit": {
+                "label": "degree Celsius",
+                "symbol": {
+                    "value": "°C",
+                    "type": "http://www.opengis.net/def/uom/UCUM/"
+                }
+            },
+            "observedProperty": {
+                "id": "https://vocab.nerc.ac.uk/standard_name/dew_point_temperature",
+                "label": "Dew Point Temperature"
+            }
+        },
+        "sq_10": {
+            "type": "Parameter",
+            "description": "Sunshine duration, duration derived from radiation, 10",
+            "unit": {
+                "label": "minute",
+                "symbol": {
+                    "value": "min",
+                    "type": "http://www.opengis.net/def/uom/UCUM/"
+                }
+            },
+            "observedProperty": {
+                "id": "https://vocab.nerc.ac.uk/standard_name/duration_of_sunshine",
+                "label": "Sunshine duration"
+            }
+        },
+        "ff_10m_10": {
+            "type": "Parameter",
+            "description": "Wind, speed, average, converted to 10 metres, 10",
+            "unit": {
+                "label": "metre per second",
+                "symbol": {
+                    "value": "m/s",
+                    "type": "http://www.opengis.net/def/uom/UCUM/"
+                }
+            },
+            "observedProperty": {
+                "id": "https://vocab.nerc.ac.uk/standard_name/wind_speed",
+                "label": "wind_speed_10_mean_PT10M"
+            }
+        }
+    }
+}

--- a/tests/test_data/edr-geojson-feature-collection.json
+++ b/tests/test_data/edr-geojson-feature-collection.json
@@ -26,62 +26,86 @@
     "parameters": {
         "tx_dryb_10": {
             "type": "Parameter",
-            "description": "Temperature, air, maximum, 10",
+            "description": {
+                "en": "Temperature, air, maximum, 10"
+            },
+            "observedProperty": {
+                "id": "https://vocab.nerc.ac.uk/standard_name/air_temperature",
+                "label": {
+                    "en": "Air temperature maximum"
+                }
+            },
             "unit": {
-                "label": "degree Celsius",
+                "label": {
+                    "en": "degree Celsius"
+                },
                 "symbol": {
                     "value": "°C",
                     "type": "http://www.opengis.net/def/uom/UCUM/"
                 }
-            },
-            "observedProperty": {
-                "id": "https://vocab.nerc.ac.uk/standard_name/air_temperature",
-                "label": "Air temperature maximum"
             }
         },
         "t_dewp_10": {
             "type": "Parameter",
-            "description": "Temperature air dewpoint 10",
+            "description": {
+                "en": "Temperature air dewpoint 10"
+            },
+            "observedProperty": {
+                "id": "https://vocab.nerc.ac.uk/standard_name/dew_point_temperature",
+                "label": {
+                    "en": "Dew Point Temperature"
+                }
+            },
             "unit": {
-                "label": "degree Celsius",
+                "label": {
+                    "en": "degree Celsius"
+                },
                 "symbol": {
                     "value": "°C",
                     "type": "http://www.opengis.net/def/uom/UCUM/"
                 }
-            },
-            "observedProperty": {
-                "id": "https://vocab.nerc.ac.uk/standard_name/dew_point_temperature",
-                "label": "Dew Point Temperature"
             }
         },
         "sq_10": {
             "type": "Parameter",
-            "description": "Sunshine duration, duration derived from radiation, 10",
+            "description": {
+                "en": "Sunshine duration, duration derived from radiation, 10"
+            },
+            "observedProperty": {
+                "id": "https://vocab.nerc.ac.uk/standard_name/duration_of_sunshine",
+                "label": {
+                    "en": "Sunshine duration"
+                }
+            },
             "unit": {
-                "label": "minute",
+                "label": {
+                    "en": "minute"
+                },
                 "symbol": {
                     "value": "min",
                     "type": "http://www.opengis.net/def/uom/UCUM/"
                 }
-            },
-            "observedProperty": {
-                "id": "https://vocab.nerc.ac.uk/standard_name/duration_of_sunshine",
-                "label": "Sunshine duration"
             }
         },
         "ff_10m_10": {
             "type": "Parameter",
-            "description": "Wind, speed, average, converted to 10 metres, 10",
+            "description": {
+                "en": "Wind, speed, average, converted to 10 metres, 10"
+            },
+            "observedProperty": {
+                "id": "https://vocab.nerc.ac.uk/standard_name/wind_speed",
+                "label": {
+                    "en": "wind_speed_10_mean_PT10M"
+                }
+            },
             "unit": {
-                "label": "metre per second",
+                "label": {
+                    "en": "metre per second"
+                },
                 "symbol": {
                     "value": "m/s",
                     "type": "http://www.opengis.net/def/uom/UCUM/"
                 }
-            },
-            "observedProperty": {
-                "id": "https://vocab.nerc.ac.uk/standard_name/wind_speed",
-                "label": "wind_speed_10_mean_PT10M"
             }
         }
     }

--- a/tests/test_edr.py
+++ b/tests/test_edr.py
@@ -5,6 +5,7 @@ import pytest
 from edr_pydantic.capabilities import LandingPageModel
 from edr_pydantic.collections import Collections
 from edr_pydantic.collections import Instance
+from edr_pydantic.edr_feature_collection import EDRFeatureCollection
 from edr_pydantic.unit import Unit
 from pydantic import ValidationError
 
@@ -13,6 +14,7 @@ happy_cases = [
     ("doc-example-collections.json", Collections),
     ("simple-instance.json", Instance),
     ("landing-page.json", LandingPageModel),
+    ("edr-geojson-feature-collection.json", EDRFeatureCollection),
 ]
 
 


### PR DESCRIPTION
The focus of regular GeoJSON is representing spatial data. EDR GeoJSON adds custom properties that help users discover what is available in the request. See here for the [optional requirements](https://docs.ogc.org/is/19-086r4/19-086r4.html#toc9).

The GeoJSON package implements the GeoJSON standards. The models inside the package ignore extra properties. Therefore it cannot be used to add the optional properties of [EDR Feature Collection GeoJSON](https://schemas.opengis.net/ogcapi/edr/1.1/openapi/schemas/edr-geojson/edrFeatureCollectionGeoJSON.yaml). In addition, I think it is nice to have validation on the parameters which a custom model makes possible.