### PR TITLE
Feature/ add symbol model properties

### DIFF
--- a/src/edr_pydantic/unit.py
+++ b/src/edr_pydantic/unit.py
@@ -7,10 +7,10 @@ from .base_model import EdrBaseModel
 
 
 class Symbol(EdrBaseModel, extra="allow"):
+    value: str
+    type: str
     title: Optional[str] = None
     description: Optional[str] = None
-    value: Optional[str] = None
-    type: Optional[str] = None
 
 
 class Unit(EdrBaseModel):

--- a/src/edr_pydantic/unit.py
+++ b/src/edr_pydantic/unit.py
@@ -7,8 +7,10 @@ from .base_model import EdrBaseModel
 
 
 class Symbol(EdrBaseModel, extra="allow"):
-    value: str
-    type: str
+    title: Optional[str] = None
+    description: Optional[str] = None
+    value: Optional[str] = None
+    type: Optional[str] = None
 
 
 class Unit(EdrBaseModel):


### PR DESCRIPTION
Added `title` and `description` fields.

The `value` and `type` fields are required as mentioned in the OGC specification requirements section A.25H. https://docs.ogc.org/is/19-086r6/19-086r6.html#req_edr_rc-parameters 

> A parameter object MAY have a member with the name "unit" where the value is an object which SHALL have either or both the members "label" or/and "symbol", and which MAY have the member "id". If given, the value of "symbol" SHALL either be a string of the symbolic notation of the unit, or an object with the members "value" and "type" where "value" is the symbolic unit notation and "type" references the unit serialization scheme that is used. "type" SHALL HAVE the value "http://www.opengis.net/def/uom/UCUM/" if UCUM is used, or a custom value as recommended in section "Extensions". If given, the value of "label" SHALL be an i18n object of the name of the unit and SHOULD be short. If given, the value of "id" SHALL be a string and SHOULD be a common identifier. It is RECOMMENDED to reference a unit serialization scheme to allow automatic unit conversion.