### PR TITLE
Replace `period` with `duration` in `MeasurementType`

### DIFF
--- a/src/edr_pydantic/parameter.py
+++ b/src/edr_pydantic/parameter.py
@@ -15,9 +15,7 @@ from .unit import Unit
 class MeasurementType(EdrBaseModel):
     method: str
     # TODO: Add validation of ISO 8601 duration (including leading minus sign)
-    # TODO: Confusion in spec on the field name, duration versus period.
-    #  See https://github.com/opengeospatial/ogcapi-environmental-data-retrieval/issues/560
-    period: str
+    duration: str
 
 
 class Parameter(EdrBaseModel, extra="allow"):

--- a/tests/test_data/doc-example-collections.json
+++ b/tests/test_data/doc-example-collections.json
@@ -198,7 +198,7 @@
                     },
                     "measurementType": {
                         "method": "mean",
-                        "duration": "-PT10M/PT0M"
+                        "duration": "-PT10M"
                     }
                 },
                 "Wind Speed": {
@@ -217,7 +217,7 @@
                     },
                     "measurementType": {
                         "method": "mean",
-                        "duration": "-PT10M/PT0M"
+                        "duration": "-PT10M"
                     }
                 },
                 "Wind Gust": {
@@ -236,7 +236,7 @@
                     },
                     "measurementType": {
                         "method": "maximum",
-                        "duration": "-PT10M/PT0M"
+                        "duration": "-PT10M"
                     }
                 },
                 "Air Temperature": {
@@ -539,7 +539,7 @@
                     },
                     "measurementType": {
                         "method": "mean",
-                        "duration": "-PT10M/PT0M"
+                        "duration": "-PT10M"
                     }
                 },
                 "Wind Speed": {
@@ -558,7 +558,7 @@
                     },
                     "measurementType": {
                         "method": "mean",
-                        "duration": "-PT10M/PT0M"
+                        "duration": "-PT10M"
                     }
                 },
                 "Wind Gust": {
@@ -577,7 +577,7 @@
                     },
                     "measurementType": {
                         "method": "maximum",
-                        "duration": "-PT10M/PT0M"
+                        "duration": "-PT10M"
                     }
                 },
                 "Air Temperature": {

--- a/tests/test_data/doc-example-collections.json
+++ b/tests/test_data/doc-example-collections.json
@@ -198,7 +198,7 @@
                     },
                     "measurementType": {
                         "method": "mean",
-                        "period": "-PT10M/PT0M"
+                        "duration": "-PT10M/PT0M"
                     }
                 },
                 "Wind Speed": {
@@ -217,7 +217,7 @@
                     },
                     "measurementType": {
                         "method": "mean",
-                        "period": "-PT10M/PT0M"
+                        "duration": "-PT10M/PT0M"
                     }
                 },
                 "Wind Gust": {
@@ -236,7 +236,7 @@
                     },
                     "measurementType": {
                         "method": "maximum",
-                        "period": "-PT10M/PT0M"
+                        "duration": "-PT10M/PT0M"
                     }
                 },
                 "Air Temperature": {
@@ -255,7 +255,7 @@
                     },
                     "measurementType": {
                         "method": "instantaneous",
-                        "period": "PT0M"
+                        "duration": "PT0M"
                     }
                 },
                 "Weather": {
@@ -274,7 +274,7 @@
                     },
                     "measurementType": {
                         "method": "instantaneous",
-                        "period": "PT0M"
+                        "duration": "PT0M"
                     }
                 },
                 "Relative Humidity": {
@@ -293,7 +293,7 @@
                     },
                     "measurementType": {
                         "method": "instantaneous",
-                        "period": "PT0M"
+                        "duration": "PT0M"
                     }
                 },
                 "Dew point": {
@@ -312,7 +312,7 @@
                     },
                     "measurementType": {
                         "method": "instantaneous",
-                        "period": "PT0M"
+                        "duration": "PT0M"
                     }
                 },
                 "Pressure": {
@@ -331,7 +331,7 @@
                     },
                     "measurementType": {
                         "method": "instantaneous",
-                        "period": "PT0M"
+                        "duration": "PT0M"
                     }
                 },
                 "Pressure Tendancy": {
@@ -350,7 +350,7 @@
                     },
                     "measurementType": {
                         "method": "instantaneous",
-                        "period": "PT0M"
+                        "duration": "PT0M"
                     }
                 },
                 "Visibility": {
@@ -369,7 +369,7 @@
                     },
                     "measurementType": {
                         "method": "instantaneous",
-                        "period": "PT0M"
+                        "duration": "PT0M"
                     }
                 }
             }
@@ -539,7 +539,7 @@
                     },
                     "measurementType": {
                         "method": "mean",
-                        "period": "-PT10M/PT0M"
+                        "duration": "-PT10M/PT0M"
                     }
                 },
                 "Wind Speed": {
@@ -558,7 +558,7 @@
                     },
                     "measurementType": {
                         "method": "mean",
-                        "period": "-PT10M/PT0M"
+                        "duration": "-PT10M/PT0M"
                     }
                 },
                 "Wind Gust": {
@@ -577,7 +577,7 @@
                     },
                     "measurementType": {
                         "method": "maximum",
-                        "period": "-PT10M/PT0M"
+                        "duration": "-PT10M/PT0M"
                     }
                 },
                 "Air Temperature": {
@@ -596,7 +596,7 @@
                     },
                     "measurementType": {
                         "method": "instantaneous",
-                        "period": "PT0M"
+                        "duration": "PT0M"
                     }
                 },
                 "Weather": {
@@ -615,7 +615,7 @@
                     },
                     "measurementType": {
                         "method": "instantaneous",
-                        "period": "PT0M"
+                        "duration": "PT0M"
                     }
                 },
                 "Relative Humidity": {
@@ -634,7 +634,7 @@
                     },
                     "measurementType": {
                         "method": "instantaneous",
-                        "period": "PT0M"
+                        "duration": "PT0M"
                     }
                 },
                 "Feels like temperature": {
@@ -653,7 +653,7 @@
                     },
                     "measurementType": {
                         "method": "instantaneous",
-                        "period": "PT0M"
+                        "duration": "PT0M"
                     }
                 },
                 "UV index": {
@@ -672,7 +672,7 @@
                     },
                     "measurementType": {
                         "method": "instantaneous",
-                        "period": "PT0M"
+                        "duration": "PT0M"
                     }
                 },
                 "Probability of precipitation": {
@@ -691,7 +691,7 @@
                     },
                     "measurementType": {
                         "method": "instantaneous",
-                        "period": "PT0M"
+                        "duration": "PT0M"
                     }
                 },
                 "Visibility": {
@@ -710,7 +710,7 @@
                     },
                     "measurementType": {
                         "method": "instantaneous",
-                        "period": "PT0M"
+                        "duration": "PT0M"
                     }
                 }
             }

--- a/tests/test_data/parameter-names.json
+++ b/tests/test_data/parameter-names.json
@@ -15,7 +15,7 @@
         },
         "measurementType": {
             "method": "instantaneous",
-            "period": "PT0S"
+            "duration": "PT0S"
         }
     },
     "u-component_of_wind_altitude_above_msl": {
@@ -34,7 +34,7 @@
         },
         "measurementType": {
             "method": "instantaneous",
-            "period": "PT0S"
+            "duration": "PT0S"
         }
     },
     "v-component_of_wind_altitude_above_msl": {
@@ -53,7 +53,7 @@
         },
         "measurementType": {
             "method": "instantaneous",
-            "period": "PT0S"
+            "duration": "PT0S"
         }
     }
 }

--- a/tests/test_data/parameter-with-extent.json
+++ b/tests/test_data/parameter-with-extent.json
@@ -39,6 +39,6 @@
     },
     "measurementType": {
         "method": "instantaneous",
-        "period": "PT0S"
+        "duration": "PT0S"
     }
 }


### PR DESCRIPTION
First off, great work on this library! It's been really useful for spec'ing out some EDR work and getting a lot of the EDR specification validated with minimal effort!

---

Historically, there has been confusion between the names `period` and `duration` for the field that denotes the ISO 8601 duration of a measurement type. This is noted in the [`TODO:` comment on `main`](https://github.com/KNMI/edr-pydantic/blob/main/src/edr_pydantic/parameter.py#L18-L19) within the `MeasurementType` model.

Now that the PR (https://github.com/opengeospatial/ogcapi-environmental-data-retrieval/pull/577) has been merged on OGC's end, there is no ambiguity between `period` and `duration` moving forward. As seen in the linked PR, the examples have been changed to confirm that `duration` is the field name moving forward with EDR v1.2.

This PR changes the field name in the `MeasurementType` model from `period` to `duration`, and changes all references from `period` to `duration` in JSON test data to ensure that tests still pass.

I appreciate that this change aligns with an upcoming EDR specification version that isn't formally released, so I welcome your steer on when it would be best to merge.

Also, I recognise that this is technically a breaking change for the library, so any thoughts on how that can be mitigated are welcome. Do we still include the `period` field as a `str | None` that is deprecated (and completely removed at a later time)? Or do we just accept that it's a breaking change and switch from `period` to `duration` without a transitional phase?

---

Related to this PR, I'm happy to pick up the other TODO comment on this field which aims to add validation for ISO 8601 duration strings (rather than accepting any strings as the model currently does).