### PR TITLE
Add support for Parameter.`data-type`

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,12 +86,13 @@ c = Collection(
             observedProperty=ObservedProperty(
                 id="https://codes.wmo.int/common/quantity-kind/_windDirection",
                 label="Wind Direction"
-            )
+            ),
+            dataType="integer"
         )
     })
 )
 
-print(c.model_dump_json(indent=2, exclude_none=True))
+print(c.model_dump_json(indent=2, exclude_none=True, by_alias=True))
 ```
 
 Will print
@@ -136,6 +137,7 @@ Will print
   "parameter_names": {
     "Wind Direction": {
       "type": "Parameter",
+      "data-type": "integer",
       "unit": {
         "label": "degree true"
       },
@@ -147,6 +149,9 @@ Will print
   }
 }
 ```
+
+**IMPORTANT**: The arguments `by_alias=True` to `model_dump_json()` or `model_dump()` is required to get the output as shown above. Without `by_alias=True` the attribute `data-type` will be wrongly outputted as `dataType`. This is due an issue in the [EDR spec](https://github.com/opengeospatial/ogcapi-environmental-data-retrieval/issues/605) and [Pydantic](https://github.com/pydantic/pydantic/issues/8379).
+
 
 ## Contributing
 

--- a/example.py
+++ b/example.py
@@ -33,9 +33,10 @@ c = Collection(
                 observedProperty=ObservedProperty(
                     id="https://codes.wmo.int/common/quantity-kind/_windDirection", label="Wind Direction"
                 ),
+                data_type="integer",
             )
         }
     ),
 )
 
-print(c.model_dump_json(indent=2, exclude_none=True))
+print(c.model_dump_json(indent=2, exclude_none=True, by_alias=True))

--- a/example.py
+++ b/example.py
@@ -33,7 +33,7 @@ c = Collection(
                 observedProperty=ObservedProperty(
                     id="https://codes.wmo.int/common/quantity-kind/_windDirection", label="Wind Direction"
                 ),
-                data_type="integer",
+                dataType="integer",
             )
         }
     ),

--- a/src/edr_pydantic/base_model.py
+++ b/src/edr_pydantic/base_model.py
@@ -10,4 +10,5 @@ class EdrBaseModel(PydanticBaseModel):
         validate_default=True,
         validate_assignment=True,
         strict=True,
+        populate_by_name=True,
     )

--- a/src/edr_pydantic/parameter.py
+++ b/src/edr_pydantic/parameter.py
@@ -24,7 +24,7 @@ class Parameter(EdrBaseModel, extra="allow"):
     id: Optional[str] = None
     label: Optional[str] = None
     description: Optional[str] = None
-    data_type: Optional[Literal["integer", "float", "string"]] = Field(None, alias="data-type")
+    dataType: Optional[Literal["integer", "float", "string"]] = Field(None, alias="data-type")  # noqa: N815
     unit: Optional[Unit] = None
     observedProperty: ObservedProperty  # noqa: N815
     extent: Optional[Extent] = None

--- a/src/edr_pydantic/parameter.py
+++ b/src/edr_pydantic/parameter.py
@@ -3,6 +3,7 @@ from typing import List
 from typing import Literal
 from typing import Optional
 
+from pydantic import Field
 from pydantic import model_validator
 from pydantic import RootModel
 
@@ -27,6 +28,7 @@ class Parameter(EdrBaseModel, extra="allow"):
     observedProperty: ObservedProperty  # noqa: N815
     extent: Optional[Extent] = None
     measurementType: Optional[MeasurementType] = None  # noqa: N815
+    data_type: Optional[Literal["integer", "float", "string"]] = Field(None, serialization_alias="data-type")
 
     @model_validator(mode="after")
     def must_not_have_unit_if_observed_property_has_categories(self):

--- a/src/edr_pydantic/parameter.py
+++ b/src/edr_pydantic/parameter.py
@@ -24,11 +24,11 @@ class Parameter(EdrBaseModel, extra="allow"):
     id: Optional[str] = None
     label: Optional[str] = None
     description: Optional[str] = None
+    data_type: Optional[Literal["integer", "float", "string"]] = Field(None, alias="data-type")
     unit: Optional[Unit] = None
     observedProperty: ObservedProperty  # noqa: N815
     extent: Optional[Extent] = None
     measurementType: Optional[MeasurementType] = None  # noqa: N815
-    data_type: Optional[Literal["integer", "float", "string"]] = Field(None, serialization_alias="data-type")
 
     @model_validator(mode="after")
     def must_not_have_unit_if_observed_property_has_categories(self):

--- a/tests/test_data/knmi-example-collections.json
+++ b/tests/test_data/knmi-example-collections.json
@@ -459,7 +459,8 @@
                     "observedProperty": {
                         "id": "https://vocab.nerc.ac.uk/standard_name/air_temperature/",
                         "label": "Air temperature maximum"
-                    }
+                    },
+                    "data-type": "float"
                 },
                 "u_10": {
                     "type": "Parameter",
@@ -489,7 +490,8 @@
                     "observedProperty": {
                         "id": "KNMI: Handboek waarnemingen",
                         "label": "Weather code (validated)"
-                    }
+                    },
+                    "data-type": "integer"
                 },
                 "ww_curr_10": {
                     "type": "Parameter",

--- a/tests/test_data/knmi-example-collections.json
+++ b/tests/test_data/knmi-example-collections.json
@@ -449,6 +449,7 @@
                 "tx_dryb_10": {
                     "type": "Parameter",
                     "description": "Temperature, air, maximum, 10'",
+                    "data-type": "float",
                     "unit": {
                         "label": "degree Celsius",
                         "symbol": {
@@ -459,8 +460,7 @@
                     "observedProperty": {
                         "id": "https://vocab.nerc.ac.uk/standard_name/air_temperature/",
                         "label": "Air temperature maximum"
-                    },
-                    "data-type": "float"
+                    }
                 },
                 "u_10": {
                     "type": "Parameter",
@@ -480,6 +480,7 @@
                 "ww_cor_10": {
                     "type": "Parameter",
                     "description": "Weather, validated code, present weather sensor, 10'",
+                    "data-type": "integer",
                     "unit": {
                         "label": "weather code",
                         "symbol": {
@@ -490,8 +491,7 @@
                     "observedProperty": {
                         "id": "KNMI: Handboek waarnemingen",
                         "label": "Weather code (validated)"
-                    },
-                    "data-type": "integer"
+                    }
                 },
                 "ww_curr_10": {
                     "type": "Parameter",

--- a/tests/test_data/parameter-invalid-data-type.json
+++ b/tests/test_data/parameter-invalid-data-type.json
@@ -1,0 +1,7 @@
+{
+    "type": "Parameter",
+    "data-type": "foobar",
+    "observedProperty": {
+        "label": "invalid parameter"
+    }
+}

--- a/tests/test_data/parameter-with-data-type.json
+++ b/tests/test_data/parameter-with-data-type.json
@@ -2,21 +2,21 @@
     "str-parameter": {
         "type": "Parameter",
         "observedProperty": {
-            "label": "Temperature_altitude_above_msl"
+            "label": "string parameter"
         },
         "data-type": "string"
     },
     "int-parameter": {
         "type": "Parameter",
         "observedProperty": {
-            "label": "u-component_of_wind_altitude_above_msl"
+            "label": "int parameter"
         },
         "data-type": "integer"
     },
     "float-parameter": {
         "type": "Parameter",
         "observedProperty": {
-            "label": "v-component_of_wind_altitude_above_msl"
+            "label": "float parameter"
         },
         "data-type": "float"
     }

--- a/tests/test_data/parameter-with-data-type.json
+++ b/tests/test_data/parameter-with-data-type.json
@@ -1,0 +1,23 @@
+{
+    "str-parameter": {
+        "type": "Parameter",
+        "observedProperty": {
+            "label": "Temperature_altitude_above_msl"
+        },
+        "data-type": "string"
+    },
+    "int-parameter": {
+        "type": "Parameter",
+        "observedProperty": {
+            "label": "u-component_of_wind_altitude_above_msl"
+        },
+        "data-type": "integer"
+    },
+    "float-parameter": {
+        "type": "Parameter",
+        "observedProperty": {
+            "label": "v-component_of_wind_altitude_above_msl"
+        },
+        "data-type": "float"
+    }
+}

--- a/tests/test_data/parameter-with-data-type.json
+++ b/tests/test_data/parameter-with-data-type.json
@@ -1,23 +1,23 @@
 {
     "str-parameter": {
         "type": "Parameter",
+        "data-type": "string",
         "observedProperty": {
             "label": "string parameter"
-        },
-        "data-type": "string"
+        }
     },
     "int-parameter": {
         "type": "Parameter",
+        "data-type": "integer",
         "observedProperty": {
             "label": "int parameter"
-        },
-        "data-type": "integer"
+        }
     },
     "float-parameter": {
         "type": "Parameter",
+        "data-type": "float",
         "observedProperty": {
             "label": "float parameter"
-        },
-        "data-type": "float"
+        }
     }
 }

--- a/tests/test_edr.py
+++ b/tests/test_edr.py
@@ -58,12 +58,12 @@ def test_error_cases(file_name, object_type, error_message):
 
 
 def test_data_type_alias():
-    p = Parameter(observedProperty=ObservedProperty(label="Wind"), data_type="integer")
+    p = Parameter(observedProperty=ObservedProperty(label="Wind"), dataType="integer")
 
     # This tests for the current observed Pydantic behavior with model_dump() and the `by_alias` setting
     assert (
         p.model_dump_json(exclude_none=True)
-        == '{"type":"Parameter","data_type":"integer","observedProperty":{"label":"Wind"}}'
+        == '{"type":"Parameter","dataType":"integer","observedProperty":{"label":"Wind"}}'
     )
     assert (
         p.model_dump_json(exclude_none=True, by_alias=True)

--- a/tests/test_edr.py
+++ b/tests/test_edr.py
@@ -1,6 +1,5 @@
 import json
 from pathlib import Path
-from typing import Dict
 
 import pytest
 from edr_pydantic.capabilities import LandingPageModel
@@ -9,8 +8,8 @@ from edr_pydantic.collections import Instance
 from edr_pydantic.extent import Extent
 from edr_pydantic.extent import Temporal
 from edr_pydantic.parameter import Parameter
+from edr_pydantic.parameter import Parameters
 from edr_pydantic.unit import Unit
-from pydantic import RootModel
 from pydantic import ValidationError
 
 happy_cases = [
@@ -19,7 +18,8 @@ happy_cases = [
     ("simple-instance.json", Instance),
     ("landing-page.json", LandingPageModel),
     ("doc-example-extent.json", Extent),
-    ("parameter-names.json", RootModel[Dict[str, Parameter]]),
+    ("parameter-names.json", Parameters),
+    ("parameter-with-data-type.json", Parameters),
     ("parameter-with-extent.json", Parameter),
 ]
 

--- a/tests/test_edr.py
+++ b/tests/test_edr.py
@@ -7,6 +7,7 @@ from edr_pydantic.collections import Collections
 from edr_pydantic.collections import Instance
 from edr_pydantic.extent import Extent
 from edr_pydantic.extent import Temporal
+from edr_pydantic.observed_property import ObservedProperty
 from edr_pydantic.parameter import Parameter
 from edr_pydantic.parameter import Parameters
 from edr_pydantic.unit import Unit
@@ -33,13 +34,14 @@ def test_happy_cases(file_name, object_type):
     json_string = json.dumps(data, separators=(",", ":"), ensure_ascii=False)
 
     # Round-trip
-    assert object_type.model_validate_json(json_string).model_dump_json(exclude_none=True) == json_string
+    assert object_type.model_validate_json(json_string).model_dump_json(exclude_none=True, by_alias=True) == json_string
 
 
 error_cases = [
     ("label-or-symbol-unit.json", Unit, r"Either 'label' or 'symbol' should be set"),
     ("temporal-interval-length1.json", Temporal, r"List should have at least 2 items after validation"),
     ("temporal-interval-length3.json", Temporal, r"List should have at most 2 items after validation, not 3"),
+    ("parameter-invalid-data-type.json", Parameter, r"Input should be 'integer', 'float' or 'string'"),
 ]
 
 
@@ -53,3 +55,17 @@ def test_error_cases(file_name, object_type, error_message):
 
     with pytest.raises(ValidationError, match=error_message):
         object_type.model_validate_json(json_string)
+
+
+def test_data_type_alias():
+    p = Parameter(observedProperty=ObservedProperty(label="Wind"), data_type="integer")
+
+    # This tests for the current observed Pydantic behavior with model_dump() and the `by_alias` setting
+    assert (
+        p.model_dump_json(exclude_none=True)
+        == '{"type":"Parameter","data_type":"integer","observedProperty":{"label":"Wind"}}'
+    )
+    assert (
+        p.model_dump_json(exclude_none=True, by_alias=True)
+        == '{"type":"Parameter","data-type":"integer","observedProperty":{"label":"Wind"}}'
+    )


### PR DESCRIPTION
Add support for `data-type`, as defined in the EDR schema:
https://github.com/opengeospatial/ogcapi-environmental-data-retrieval/blob/master/core/standard/openapi/oas31/schemas/collections/parameterNames.yaml#L16